### PR TITLE
Fix path to examples folder in documentation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,6 @@
 
 `papyrus` offers a broad API to enable embedding and customisation. Each module which provides this
 functionality has documentation and there are
-[examples](https://github.com/kurtlawrence/papyrus/tree/master/papyrus/examples)
+[examples](https://github.com/kurtlawrence/papyrus/tree/master/examples)
 that can be used as a guide.
 


### PR DESCRIPTION
The old link (https://github.com/kurtlawrence/papyrus/tree/master/papyrus/examples) is opening up a 404 page